### PR TITLE
Highscore functionality

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,9 @@
         "pathfinding",
         "pimodules",
         "pygame",
+        "pygbag",
         "pyved",
-        "tileset"
+        "tileset",
+        "venv"
     ]
 }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Sample project based on [Pyved engine](https://github.com/gaudiatech/pyved-engine) using ECS Roguelike template
 
-![](/screenshots/screenshot.png)
+![screenshot](/screenshots/screenshot.png)
 
 Core project is taken from engine repo [t-workshop/ECSRogue](https://github.com/gaudiatech/pyved-engine/tree/master/t-workshop/ECSRogue).
 

--- a/ecsRogue/cartridge/classes.py
+++ b/ecsRogue/cartridge/classes.py
@@ -7,7 +7,7 @@ pg = pimodules.pyved_engine.pygame
 
 class InputBox:
     # https://stackoverflow.com/questions/46390231/how-can-i-create-a-text-input-box-with-pygame
-    def __init__(self, x, y, w, h, text='', max_len=0):
+    def __init__(self, x, y, w, h, text="", max_len=0):
         self.rect = pg.Rect(x, y, w, h)
         self.color = shared.COLOR_ACTIVE
         self.max_len = max_len
@@ -19,8 +19,9 @@ class InputBox:
 
     def render_text(self):
         suffix = "_" if self.active else ""
-        self.txt_surface = self.ft.render(f"{self.text}{suffix}", True, self.color,
-                                          "black")  # FONT.render(self.text, True, self.color)
+        self.txt_surface = self.ft.render(
+            f"{self.text}{suffix}", True, self.color,
+            "black")  # FONT.render(self.text, True, self.color)
 
     def handle_event(self, event):
         if event.type == pg.MOUSEBUTTONDOWN:
@@ -40,11 +41,12 @@ class InputBox:
                     # self.color = shared.COLOR_ACTIVE if self.active else shared.COLOR_INACTIVE
                     # self.render_text()
                     shared.show_input = False
+                    shared.user_name = None
                 elif event.key == pg.K_RETURN:
                     # print(self.text)
                     shared.user_name = self.text
                     shared.show_input = False
-                    self.text = ''
+                    self.text = ""
                 elif event.key == pg.K_BACKSPACE:
                     self.text = self.text[:-1]
                 elif event.key not in [pg.K_TAB]:
@@ -62,7 +64,7 @@ class InputBox:
 
     def draw(self, screen):
         # Blit the text.
-        pg.draw.rect(screen, 'black', self.rect)
+        pg.draw.rect(screen, "black", self.rect)
         screen.blit(self.txt_surface, (self.rect.x + 5, self.rect.y + 5))
         # Blit the rect.
         pg.draw.rect(screen, self.color, self.rect, 2)

--- a/ecsRogue/cartridge/gamedef.py
+++ b/ecsRogue/cartridge/gamedef.py
@@ -95,8 +95,10 @@ def init_menu():
                 submitRequests=True
             )
         else:
+            print("*" * 50)
             print("GameJolt API needs proper GAME_ID, PRIVATE_KEY and PROD_SCORE_TABLE_ID to be set. See shared.py for more details.")
             print("HIGHSCORE table will be disabled.")
+            print("*" * 50)
 
     shared.user_name_input = InputBox(135, 205, 140, 32, max_len=10)
 

--- a/ecsRogue/cartridge/gamedef.py
+++ b/ecsRogue/cartridge/gamedef.py
@@ -2,7 +2,12 @@ from . import pimodules
 from . import shared
 from . import systems
 from . import world
+from .util import clear_local_score_table
+# from pygame_menu.examples import create_example_window
 
+# from . import gamejoltapi
+if not shared.IS_WEB:
+    import gamejoltapi
 
 pyv = pimodules.pyved_engine
 pygame = pyv.pygame
@@ -57,6 +62,18 @@ def load_fonts():
 
 
 def init_menu():
+    # import pygame_menu
+    # pygame_menu_ce not working with pygbag:
+    #   File "/data/data/ecsrogue/assets/cartridge/systems.py", line 266, in rendering_sys
+    #     shared.menu.draw(view)
+    #   File "/data/data/org.python/assets/build/env/pygame_menu/menu.py", line 2117, in draw
+    #     self._current._menubar.draw(surface)
+    #   File "/data/data/org.python/assets/build/env/pygame_menu/widgets/core/widget.py", line 1391, in draw
+    #     self._draw(surface)
+    #   File "/data/data/org.python/assets/build/env/pygame_menu/widgets/widget/menubar.py", line 250, in _draw
+    #     gfxdraw.filled_polygon(surface, self._polygon_pos, self._background_color)
+    # pygame.error: Parameter 'renderer' is invalid
+    
     # shared.menu = pygame_menu.Menu(
     #     height=300,
     #     theme=pygame_menu.themes.THEME_BLUE,
@@ -67,14 +84,20 @@ def init_menu():
     # # menu.add.selector('Difficulty: ', [('Hard', 1), ('Easy', 2)], onchange=set_difficulty)
     # shared.menu.add.button('Play', start_game)
     # shared.menu.add.button('Quit', pygame_menu.events.EXIT)
-    # shared.gamejoltapi = gamejoltapi.GameJoltAPI(
-    #     shared.GAME_ID,
-    #     shared.PRIVATE_KEY,
-    #     # username=USERNAME,
-    #     # userToken=TOKEN,
-    #     responseFormat="json",
-    #     submitRequests=True
-    # )
+    if not shared.IS_WEB:
+        if len(shared.GAME_ID) > 0 and len(shared.PRIVATE_KEY) > 0 and shared.PROD_SCORE_TABLE_ID > 0:
+            shared.gamejoltapi = gamejoltapi.GameJoltAPI(
+                shared.GAME_ID,
+                shared.PRIVATE_KEY,
+                # username=USERNAME,
+                # userToken=TOKEN,
+                responseFormat="json",
+                submitRequests=True
+            )
+        else:
+            print("GameJolt API needs proper GAME_ID, PRIVATE_KEY and PROD_SCORE_TABLE_ID to be set. See shared.py for more details.")
+            print("HIGHSCORE table will be disabled.")
+
     shared.user_name_input = InputBox(135, 205, 140, 32, max_len=10)
 
 
@@ -101,6 +124,7 @@ def init_game(vmst=None):
     load_fonts()
     init_menu()
 
+    # clear_local_score_table()
     pyv.bulk_add_systems(systems)
 
 

--- a/ecsRogue/cartridge/metadat.json
+++ b/ecsRogue/cartridge/metadat.json
@@ -1,1 +1,24 @@
-{"vmlib_ver": "24_4a2", "dependencies": {"pyved_engine": "???"}, "description": "this is a placeholder so you can describe your game", "author": "Unknown", "assets": ["smallninja_sprites.json", "tileset.png", "monster.png", "exit_tile.png", "pot_tile.png"], "sounds": [], "slug": "ecsRogue", "title": "Roguelike Template", "build_date": "Wed  Sep 20 15:55:17 2023", "thumbnail512x384": "thumb_2.png", "thumbnail512x512": "thumb_1.png", "ktg_services": false, "instructions": "Controls: arrow keys to move | h for Help | Space to restart/generate a new maze", "game_title": "ecsRogue"}
+{
+    "vmlib_ver": "24_4a2",
+    "dependencies": {
+        "pyved_engine": "???"
+    },
+    "description": "this is a placeholder so you can describe your game",
+    "author": "Unknown",
+    "assets": [
+        "smallninja_sprites.json",
+        "tileset.png",
+        "monster.png",
+        "exit_tile.png",
+        "pot_tile.png"
+    ],
+    "sounds": [],
+    "slug": "ecsRogue",
+    "title": "Roguelike Template",
+    "build_date": "Wed  Sep 20 15:55:17 2023",
+    "thumbnail512x384": "thumb_2.png",
+    "thumbnail512x512": "thumb_1.png",
+    "ktg_services": false,
+    "instructions": "Controls: arrow keys to move | h for Help | Space to restart/generate a new maze",
+    "game_title": "ecsRogue"
+}

--- a/ecsRogue/cartridge/shared.py
+++ b/ecsRogue/cartridge/shared.py
@@ -30,7 +30,7 @@ if __import__("sys").platform == "emscripten":
 #    * it's restored to original state with each game run
 
 # Local storage stub for testing highscore in desktop mode
-USE_HIGHSCORE_STUB = False
+USE_HIGHSCORE_STUB = True
 HIGHSCORE_STUB = {
     # "Ula": {"level": 3, "stored_timestamp": "1712989042.312", "game_ver": "0.9", "time_played": "n/a"},
     # "Hubi": {"level": 2, "stored_timestamp": "1712988963.14", "game_ver": "0.9", "time_played": "n/a"},

--- a/ecsRogue/cartridge/shared.py
+++ b/ecsRogue/cartridge/shared.py
@@ -1,21 +1,59 @@
-# from . import gamejoltapi
+GAME_VER = "0.9"
+# print exceptions in GUI only in debug mode (useful for debugging highscore local web storage when there is no terminal)
+IS_DEBUG = True # check if we can use __debug__ with pyved and pygbag
 
 show_input = False
 user_name_input = None 
 user_name = None 
 
 fonts = {}
-### TODO: Highscore WIP
+# Need a flag to handle differently when game is run in desktop mode or in a web browser
+IS_WEB = False
+# local storage in web version for high score table
+if __import__("sys").platform == "emscripten":
+    IS_WEB = True
+    
+### Highscore utils
+# there are 3 implementations of highscore:
+# 1. using GameJolt API for desktop mode
+#    * unfortunately it doesn't work yet when run in the web browser
+#    * API does the all heavy lifting
+#    * scores are kept online and there is one common score board for all users no matter when the game is run
+# 2. Local storage in web browser
+#    * uses the build in Web browser functionality called 'local storage'
+#    * highscore table is kept in your browser locally and bind to url (domain:port, eg.: pyvm.kata.games, localhost:8000, 127.0.0.1:8000) so it's decentralized
+#    * it can be viewed and edited in browser (e.g. in Chrome: Developer Tools -> Applications -> Storage -> Local storage -> url)
+# 3. Local storage stub
+#    * stubs local storage to make it easier to debug
+#    * when enabled, you can run game in desktop mode and still test it (view console, quick restart, etc.)
+#    * the data is kept in global dictionary (HIGHSCORE_STUB) instead of actual browser local storage
+#    * it's restored to original state with each game run
+
+# Local storage stub for testing highscore in desktop mode
+USE_HIGHSCORE_STUB = False
+HIGHSCORE_STUB = {
+    # "Ula": {"level": 3, "stored_timestamp": "1712989042.312", "game_ver": "0.9", "time_played": "n/a"},
+    # "Hubi": {"level": 2, "stored_timestamp": "1712988963.14", "game_ver": "0.9", "time_played": "n/a"},
+    # "Master": {"level": 4, "stored_timestamp": "1712989177.01", "game_ver": "0.9", "time_played": "n/a"},
+    # "Noob": {"level": 2, "stored_timestamp": "1712989177.01", "game_ver": "0.9", "time_played": "n/a"},
+    # "Ela": {"level": 1, "stored_timestamp": "1712989127.556", "game_ver": "0.9", "time_played": "n/a"},
+    # "Ala": {"level": 1, "stored_timestamp": "1712988973.809", "game_ver": "0.9", "time_played": "n/a"},
+}
+if USE_HIGHSCORE_STUB:
+    IS_WEB = True
+
+# GameJolt API
 # go to https://gamejolt.com/
 # create account
 # crate new game
-GAME_VER = "0.9"
-GAME_ID = "<YOUR_GAME_ID>"
-PRIVATE_KEY = "YOUR_KEY"
+GAME_ID = "" # <YOUR_GAME_ID>
+PRIVATE_KEY = "" # <YOUR_KEY>
 gamejoltapi = None
 TEST_SCORE_TABLE_ID = 0 # create test score table and enter it's id here
 PROD_SCORE_TABLE_ID = 0 # open default score table and enter it's id here
 SCORE_TABLE = []
+SCORES = {}
+NO_TOP_SCORES = 10
 
 screen = None
 is_game_over = False
@@ -25,22 +63,22 @@ game_over_msgs_hs = [
     "Game Over",
     'You reached level : {level_count}',
     'Provide your name for highscore table',
-    'Press [q] to cancel or [ENTER] to accept',
+    'Press [ESC] to cancel or [ENTER] to accept',
     'Name:'
 ]
 game_over_msgs = [
     "Game Over",
     'You reached level: {level_count}',
-    'Press [q] to quit or [SPACE] to restart',
+    'Press {exit}[SPACE] to restart'.format(exit=('' if IS_WEB else '[ESC] to quit or ')),
 ]
 
 help_msgs = [
     "[ARROWS] - to move",
-    # "[s] - show highscore",
-    "[q] - exit",
-    "[SPACE] - new maze",
+    "[s] - show highscore",
+    ('' if IS_WEB else '[ESC] - exit'),
     "",
     "*** CHEATS/DEBUG ***",
+    "[SPACE] - new maze",
     "[m] - show enemy",
     "[a] - activate enemies",
     "[p] - show enemy path",
@@ -65,6 +103,7 @@ CELL_SIDE = 32  # px
 MAZE_SIZE = (24, 23)
 WALL_COLOR = (8, 8, 24)
 HIDDEN_CELL_COLOR = (24, 24, 24)
+# user_name input label colors
 COLOR_INACTIVE = 'yellow4' # shared.HIDDEN_CELL_COLOR # pygame.Color('lightskyblue3')
 COLOR_ACTIVE = 'yellow' # pygame.Color('dodgerblue2')
 
@@ -99,10 +138,13 @@ MAX_POTIONS = 4
 MAX_MONSTERS = 4
 SHOW_HELP = False
 SHOW_HIGHSCORE = False
+# CHEATS/DEBUG
 EXIT_VISIBLE = False
 ALL_POTIONS_VISIBLE = False
 ALL_MONSTERS_VISIBLE = False
 ALL_MONSTERS_PATH_VISIBLE = False
+# if any of the above features is used, highscore won't be saved
+CHEAT_USED = False
 
 walkable_cells = []  # List to store walkable cells
 level_count = 1

--- a/ecsRogue/cartridge/systems.py
+++ b/ecsRogue/cartridge/systems.py
@@ -53,7 +53,7 @@ def pg_event_proces_sys():
             if ev.type == pg.KEYDOWN:
                 if ev.key in [pg.K_ESCAPE, pg.K_q]:
                     # ending game in WEB doesn't make sense (the game freezes)
-                    if not shared.shared.IS_WEB:
+                    if not shared.IS_WEB or shared.USE_HIGHSCORE_STUB:
                         pyv.vars.gameover = True
                 elif ev.key == pg.K_SPACE:
                     # use flag so we we'll reset level, soon in the future
@@ -78,7 +78,7 @@ def pg_event_proces_sys():
             # print(ev.key, pg.K_ESCAPE)
             if ev.key in [pg.K_ESCAPE, pg.K_q]:
                 # ending game in WEB doesn't make sense (the game freezes)
-                if not shared.shared.IS_WEB:
+                if not shared.IS_WEB or shared.USE_HIGHSCORE_STUB:
                     pyv.vars.gameover = True
             elif ev.key == pg.K_UP:
                 player_pos[1] -= 1

--- a/ecsRogue/cartridge/util.py
+++ b/ecsRogue/cartridge/util.py
@@ -5,7 +5,8 @@ it's important to keep utility functions separate from sysstems.py for the a bet
 from datetime import datetime
 import asyncio
 # import aiohttp
-# import json
+import json
+import time
 # import inspect
 from . import shared
 from . import world
@@ -23,65 +24,370 @@ pg = pyv.pygame
 #         async with session.get(url) as response:
 #             return await response.json()
 
-
+# --------------------------
+# rendering helper functions
+# --------------------------
 def render_messages(scr):
-    classic_ftsize = 24
-    # render_rows_of_text(scr, 22*32, 24, classic_ftsize, shared.help_msgs)
-    ft = shared.fonts[classic_ftsize]  # pyv.pygame.font.Font(None, classic_ftsize)
+    # render last 12 game events in lower right part of screen
+    font_size = 24
+    ft = shared.fonts[font_size]
+    # reverse order (printed from bottom of screen up) limit to 12 last messages
     for i, msg in enumerate(shared.messages[::-1][:12]):
-        label = ft.render(msg, True, 'yellow', 'black')
-        scr.blit(label, (22 * 32, shared.SCR_HEIGHT - ((i + 1) * classic_ftsize)))
+        label = ft.render(msg, True, "yellow", "black")
+        scr.blit(label, (22 * 32, shared.SCR_HEIGHT - ((i + 1) * font_size)))
 
 
 def render_help(scr):
-    classic_ftsize = 24
-    render_rows_of_text(scr, 22 * 32, 38, classic_ftsize, shared.help_msgs)
+    # render help messages with key bindings in upper right part of screen
+    font_size = 24
+    render_rows_of_text(scr, 22 * 32, 38, font_size, shared.help_msgs)
 
 
-def render_rows_of_text(scr, x, y, font_size, msgs, text_color='yellow', bg_color='black'):
-    ft = shared.fonts[font_size]  # pyv.pygame.font.Font(None, font_size)
+def render_rows_of_text(scr, x, y, font_size, msgs, bg_panel=True, text_color="yellow", bg_color="black"):
+    # prints rows of text, one under another in given position, with black panel as background (if bg_panel)
+    ft = shared.fonts[font_size]
+    if bg_panel:
+        pg.draw.rect(scr, "black", [x - 5, y - 5, shared.SCR_WIDTH - 150, (len(msgs) + 1) * font_size])
+        
     for i, msg in enumerate(msgs):
-        label = ft.render(msg, True, text_color, bg_color)
+        label = ft.render(str(msg), True, text_color, bg_color)
         scr.blit(label, (x, (y + (i * font_size))))
 
 
-async def get_score_table():
+def split_string(text, length):
+    # cuts string into equal length chunks (e.g. to fit into panel)
+    return (text[0+i:length+i] for i in range(0, len(text), length))
+
+# --------------------------
+# HIGHSCORE functions
+# --------------------------
+
+
+### TODO: Highscore WIP
+# async def _urlopen_async(url):
+#     async with aiohttp.ClientSession() as session:
+#         async with session.get(url) as response:
+#             return await response.json()
+
+def get_desktop_rank():
+    # extracts rank (position on highscore list) from highscore table
+    # Game Jolt API version (desktop mode)
+    rank = -1
+    res = shared.gamejoltapi.scoresFetch(shared.NO_TOP_SCORES, shared.TEST_SCORE_TABLE_ID)
+    if res["success"]:
+        for i, data in enumerate(res["scores"]):
+            if data["guest"] == shared.user_name:
+                rank = i + 1
+                break
+    
+    return rank
+
+def prepare_desktop_score():
+    # prepares and stores score data of current user
+    # and generate messages based on old and new rank
+    # Game Jolt API version (desktop mode)
+    
+    if not shared.gamejoltapi:
+        return
+    
+    extra_info = {
+                "game_ver": shared.GAME_VER,
+                "time_played": "n/a"
+    }
+    old_rank = get_desktop_rank()
+
+    shared.gamejoltapi.scoresAdd(
+        f"level {shared.level_count}", 
+        shared.level_count, 
+        shared.TEST_SCORE_TABLE_ID, 
+        shared.user_name, 
+        json.dumps(extra_info)
+    )
+    
+    new_rank = get_desktop_rank()
+    add_messages_based_on_ranks(old_rank, new_rank)
+
+
+def prepare_web_score():
+    # prepares and stores score data of current user
+    # and generate messages based on old and new rank
+    # Local storage version (web browser)
+    
+    data = {
+        "level": shared.level_count,
+        "stored_timestamp": str(time.time()),
+        "game_ver": shared.GAME_VER,
+        "time_played": "n/a"
+    }
+    scores = get_scores()
+    old_rank = get_score_rank(scores)
+    update_score(scores, data)
+    
+    # if changed then store locally
+    if scores[shared.user_name] == data:
+        set_web_score(data)
+    
+    # sort and limit results to top NO_TOP_SCORES
+    top_scores = get_top_scores(scores)
+    # removed scores outside of top list from local stored 
+    clear_worst_scores(top_scores)
+    new_rank = get_score_rank(scores)
+    add_messages_based_on_ranks(old_rank, new_rank)
+    shared.SCORES = top_scores
+    ### TODO: Highscore WIP
+    if shared.USE_HIGHSCORE_STUB:
+        shared.HIGHSCORE_STUB = top_scores
+
+
+def add_messages_based_on_ranks(old_rank, new_rank):
+    # adds motivational messages depending on how did players rank in highscore table changed
+    
+    if new_rank == -1:
+        shared.messages.append("More luck next time!")
+    elif old_rank == -1: 
+        if new_rank > 0:
+            shared.messages.append(f"Your first rank is {new_rank}")
+    else:
+        if new_rank > old_rank:
+            if new_rank == 1:
+                shared.messages.append(f"Congrats! You're number one!")
+            elif new_rank == 2:
+                shared.messages.append(f"Congrats! Almost at the top!")
+            elif new_rank == 3:
+                shared.messages.append(f"Congrats! You're on podium!")
+            else:
+                shared.messages.append("You've past your previous rank")
+            shared.messages.append(f"Your new rank is {new_rank}")
+        else:
+            shared.messages.append(f"You're previous rank was {old_rank}")
+
+
+def set_web_score(data):
+    # stores score data locally
+    # Local storage version (web browser) or STUB
+    
+    if shared.USE_HIGHSCORE_STUB:
+        return
+    ### TODO: Highscore WIP
+    try:
+        data_str = json.dumps(data)
+        from platform import window
+        window.localStorage.setItem(shared.user_name, data_str)
+        
+    except Exception as e:
+        if shared.IS_DEBUG:
+            e_str = str(e)
+            shared.messages.append(f"Error set_web_score")
+            shared.messages += split_string(e_str, 30)
+
+
+def get_scores():
+    # get scores from local storage
+    # return empty dict if failed
+    # Local storage version (web browser) or STUB
+    
+    if shared.USE_HIGHSCORE_STUB:
+        return shared.HIGHSCORE_STUB
+    ### TODO: Highscore WIP
+    try:
+        from platform import window
+        
+        scores = {}
+        for i in range(window.localStorage.length):
+            user_name = window.localStorage.key(i)
+            data = window.localStorage.getItem(user_name)
+            score = json.loads(data)
+            scores[user_name] = score
+    except Exception as e:
+        scores = {}
+        if shared.IS_DEBUG:
+            shared.messages.append(f"Error get_scores")
+            s = str(e)
+            shared.messages += split_string(s, 30)
+    finally:
+        return scores
+
+
+def update_score(scores, score_data):
+    # updates score only if level achieved is higher 
+    # (when equal still updates to sort by timestamp or plaid time in future)
+    # Local storage version (web browser) or STUB
+    
+    if shared.user_name in scores:
+        if scores[shared.user_name]["level"] <= score_data["level"]:
+            scores[shared.user_name] = score_data
+    else:
+        scores[shared.user_name] = score_data
+    
+    return scores
+
+
+def get_score_rank(scores):
+    # returns rank - position on highscore list (first == 1) 
+    # or -1 if not listed
+    # Local storage version (web browser) or STUB
+
+    user_names = list(get_top_scores(scores).keys())
+    rank = -1
+    if shared.user_name in user_names:
+        rank = user_names.index(shared.user_name) + 1
+    return rank
+
+
+def get_top_scores(scores):
+    # sort descending by level, than by timestamp from earliest (time when scored) 
+    # and return only top N (NO_TOP_SCORES)
+    # original 'scores' dict parameter is not affected
+    # Local storage version (web browser) or STUB
+
+    return dict(sorted(scores.items(), key=lambda kv: ((-kv[1]["level"], -float(kv[1]["stored_timestamp"])), kv[0]))[:shared.NO_TOP_SCORES])
+
+
+def clear_local_score_table():
+    # clears score data from local storage
+    # Local storage version (web browser) or STUB
+    
+    ### TODO: Highscore WIP
+    if shared.IS_WEB:
+        try:
+            from platform import window
+            keys = []
+            for i in range(window.localStorage.length):
+                keys.append(window.localStorage.key(i))
+            while keys: 
+                window.localStorage.removeItem(keys.pop())
+        except:
+            pass
+
+
+def clear_worst_scores(top_scores):
+    # removes scores from local storage if not in "top_scores" dict parameter
+    # (assuming "top_scores" is result of get_top_scores() )
+    # Local storage version (web browser) or STUB
+
+    if shared.USE_HIGHSCORE_STUB:
+        top_user_names = top_scores.keys()
+        all_user_names = list(shared.HIGHSCORE_STUB.keys())
+        # users_to_clear = []
+        for user_name in all_user_names:
+            if user_name not in top_user_names:
+                del shared.HIGHSCORE_STUB[user_name]
+                
+        return
+    ### TODO: Highscore WIP
+    try:
+        from platform import window
+        
+        top_user_names = top_scores.keys()
+        users_to_clear = []
+        for i in range(window.localStorage.length):
+            user_name = window.localStorage.key(i)
+            if user_name not in top_user_names:
+                users_to_clear.append(user_name)
+                
+        while users_to_clear: 
+            window.localStorage.removeItem(users_to_clear.pop())
+    finally:
+        pass
+
+
+def get_web_score_table():
+    # converts scores dict to tables of strings to be rendered
+    # Local storage version (web browser) or STUB
+    
+    shared.SCORE_TABLE = []
+    if len(shared.SCORES) == 0:
+        shared.SCORES = get_scores()
+        
+    rank = 0
+    try:
+        shared.SCORE_TABLE.append(["Rank", "Name", "Level", "Date"])
+        for user_name, score in get_top_scores(shared.SCORES).items():
+            rank += 1
+            try:
+                stored_timestamp = float(score["stored_timestamp"])
+                ts = datetime.fromtimestamp(stored_timestamp).strftime("%Y-%m-%d %H:%M:%S")
+            except:
+                ts = "n/a"
+            shared.SCORE_TABLE.append([str(rank), user_name, str(score["level"]), ts])
+        if len(shared.SCORE_TABLE) == 1:
+            shared.SCORE_TABLE = ["Highscore table is empty"]
+    except Exception as e:
+        shared.SCORE_TABLE = ["Highscore table temporally unavailable"]
+        if shared.IS_DEBUG:
+            shared.messages.append(f"Error in get_web_score_table")
+            s = str(e)
+            shared.messages += split_string(s, 30) 
+        
+        
+def get_score_table():
+    # gets scores using gamejoltapi and converts to tables of strings to be rendered
+    # Game Jolt API version (desktop mode)
+    
+    if not shared.gamejoltapi:
+        shared.SCORE_TABLE.append("Highscore table temporally unavailable")
+        return
+    
+    scores_payload = shared.gamejoltapi.scoresFetch(shared.NO_TOP_SCORES, shared.TEST_SCORE_TABLE_ID)
+    shared.SCORE_TABLE = []
+    if scores_payload["success"]:
+        shared.SCORE_TABLE.append(["Rank", "Name", "Level", "Date"])
+        for rank, score in enumerate(scores_payload["scores"]):
+            ts = f"{datetime.fromtimestamp(score["stored_timestamp"])}"
+            shared.SCORE_TABLE.append([str(rank+1), score["guest"], score["sort"], ts])
+    else:
+        shared.SCORE_TABLE.append("Highscore table temporally unavailable")
+        
+        
+async def get_score_table_async():
+    # gets scores using gamejoltapi and converts to tables of strings to be rendered
+    # WEB async version using Game Jolt API - NOT WORKING with pygbag
+    
     # res = await _urlopen_async("https://postman-echo.com/delay/2")
     # print(res)
     # return
 
-    # get top 10 scores
+    # get top scores
     # print("gamejoltapi.scoresFetch")
-    scores_payload = await shared.gamejoltapi.scoresFetch(10, shared.TEST_SCORE_TABLE_ID)
+    if not shared.gamejoltapi:
+        shared.SCORE_TABLE.append("Highscore table temporally unavailable")
+        return
+
+    scores_payload = await shared.gamejoltapi.scoresFetch(shared.NO_TOP_SCORES, shared.TEST_SCORE_TABLE_ID)
     # print(scores_payload)
     shared.SCORE_TABLE = []
     if scores_payload["success"]:
         shared.SCORE_TABLE.append(["Rank", "Name", "Level", "Date"])
         # print(scores_payload["scores"][0])
         for rank, score in enumerate(scores_payload["scores"]):
-            ts = f"{datetime.fromtimestamp(score['stored_timestamp'])}"
-            shared.SCORE_TABLE.append([str(rank + 1), score["guest"], score["sort"], ts])
+            ts = f"{datetime.fromtimestamp(score["stored_timestamp"])}"
+            shared.SCORE_TABLE.append([str(rank+1), score["guest"], score["sort"], ts])
     else:
         shared.SCORE_TABLE.append("Highscore table temporally unavailable")
 
 
 def render_score_table(scr):
-    # asyncio.run(get_score_table())
-    # return
-    if len(shared.SCORE_TABLE) == 0:
-        # get_score_table()
-        asyncio.run(get_score_table())
-
-    if len(shared.SCORE_TABLE) == 1:
-        render_rows_of_text(scr, 50, 50, 38, shared.SCORE_TABLE)
+    # render highscore table with top results
+    
+    if shared.IS_WEB:
+        get_web_score_table()
     else:
-        font_size = 38
+        get_score_table()
+        # asyncio.run(get_score_table_async())
+    columns_x = [50, 50 + 80, 50 + 80 + 200, 50 + 80 + 250+ 80, 50 + 80 + 250 + 80 + 240]
+    rows_cnt = len(shared.SCORE_TABLE)
+    font_size = 38
+
+    if rows_cnt == 1:
+        render_rows_of_text(scr, 50, 100, 38, shared.SCORE_TABLE)
+    else:
+        # black panel under score table
+        pg.draw.rect(scr, "black", [25, 100 - 20, columns_x[4], (rows_cnt + 1) * font_size])
+        
         ft = shared.fonts[font_size]
-        columns_x = [50, 50 + 80, 50 + 80 + 200, 50 + 80 + 250 + 80, ]
         for j, row in enumerate(shared.SCORE_TABLE):
-            # print(row)
-            for i, x in enumerate(columns_x):
-                label = ft.render(row[i], True, 'yellow', 'black')
+            for i, x in enumerate(columns_x[:-1]):
+                label = ft.render(row[i], True, "yellow", "black")
                 scr.blit(label, (x, (100 + (j * font_size))))
 
 
@@ -90,22 +396,22 @@ def render_score_table(scr):
 #  utility functions
 # ----------------------------
 def draw_all_mobs(scrref):
-    player = pyv.find_by_archetype('player')[0]
-    monsters = pyv.find_by_archetype('monster')
-    av_i, av_j = player['position']
-    exit_ent = pyv.find_by_archetype('exit')[0]
-    potions = pyv.find_by_archetype('potion')
+    player = pyv.find_by_archetype("player")[0]
+    monsters = pyv.find_by_archetype("monster")
+    av_i, av_j = player["position"]
+    exit_ent = pyv.find_by_archetype("exit")[0]
+    potions = pyv.find_by_archetype("potion")
 
     # draw the exit
-    if shared.game_state['visibility_m'].get_val(*exit_ent['position']) or shared.EXIT_VISIBLE:
+    if shared.game_state["visibility_m"].get_val(*exit_ent["position"]) or shared.EXIT_VISIBLE:
         if shared.TILESET:
             adhoc_exit_tile = shared.TILESET.image_by_rank(shared.EXIT_TILE_RANK)
         else:
             adhoc_exit_tile = shared.exit_tile
         scrref.blit(
             adhoc_exit_tile, (
-                exit_ent['position'][0] * shared.CELL_SIDE,
-                exit_ent['position'][1] * shared.CELL_SIDE,
+                exit_ent["position"][0] * shared.CELL_SIDE,
+                exit_ent["position"][1] * shared.CELL_SIDE,
                 shared.CELL_SIDE,
                 shared.CELL_SIDE
             )
@@ -113,19 +419,19 @@ def draw_all_mobs(scrref):
 
     # draw all potions
     for potion in potions:
-        if shared.game_state['visibility_m'].get_val(*potion['position']) or shared.ALL_POTIONS_VISIBLE:
+        if shared.game_state["visibility_m"].get_val(*potion["position"]) or shared.ALL_POTIONS_VISIBLE:
             # print("show potion")
-            if potion['effect'] == 'Heal':
+            if potion["effect"] == "Heal":
                 img_index = shared.HEAL_TILE_RANK if shared.ALL_POTIONS_VISIBLE else shared.UNKNOWN_TILE_RANK
-                # scrref.blit(shared.TILESET.image_by_rank(783), (potion['position'][0] * shared.CELL_SIDE, potion['position'][1] * shared.CELL_SIDE, shared.CELL_SIDE, shared.CELL_SIDE))
-            elif potion['effect'] == 'Poison':
+                # scrref.blit(shared.TILESET.image_by_rank(783), (potion["position"][0] * shared.CELL_SIDE, potion["position"][1] * shared.CELL_SIDE, shared.CELL_SIDE, shared.CELL_SIDE))
+            elif potion["effect"] == "Poison":
                 img_index = shared.POISON_TILE_RANK if shared.ALL_POTIONS_VISIBLE else shared.UNKNOWN_TILE_RANK
             else:
                 continue
             adhoc_pot_tile = shared.TILESET.image_by_rank(img_index) if shared.TILESET else shared.pot_tile
             scrref.blit(
                 adhoc_pot_tile,
-                (potion['position'][0] * shared.CELL_SIDE, potion['position'][1] * shared.CELL_SIDE, shared.CELL_SIDE,
+                (potion["position"][0] * shared.CELL_SIDE, potion["position"][1] * shared.CELL_SIDE, shared.CELL_SIDE,
                  shared.CELL_SIDE))
 
     # fait une projection coordonnées i,j de matrice vers targx, targy coordonnées en pixel de l'écran
@@ -135,18 +441,18 @@ def draw_all_mobs(scrref):
 
     # draw all enemies
     for monster in monsters:
-        pos = monster['position']
+        pos = monster["position"]
         # pos, t = enemy_info
-        if shared.ALL_MONSTERS_VISIBLE or shared.game_state['visibility_m'].get_val(*pos):
+        if shared.ALL_MONSTERS_VISIBLE or shared.game_state["visibility_m"].get_val(*pos):
             en_i, en_j = pos[0] * shared.CELL_SIDE, pos[1] * shared.CELL_SIDE
             if shared.ALL_MONSTERS_PATH_VISIBLE:
-                pg.draw.rect(scrref, monster['color'], (en_i, en_j, shared.CELL_SIDE, shared.CELL_SIDE))
-                if len(monster['path']) > 1:
-                    delta_x = (monster['no'] // 4) * 8
-                    delta_y = (int(monster['no'] % 4)) * 8
-                    for path_pos in monster['path'][1:-1]:
+                pg.draw.rect(scrref, monster["color"], (en_i, en_j, shared.CELL_SIDE, shared.CELL_SIDE))
+                if len(monster["path"]) > 1:
+                    delta_x = (monster["no"] // 4) * 8
+                    delta_y = (int(monster["no"] % 4)) * 8
+                    for path_pos in monster["path"][1:-1]:
                         pg.draw.rect(
-                            scrref, monster['color'], (
+                            scrref, monster["color"], (
                                 (path_pos[0] * shared.CELL_SIDE) + 4 + delta_x,
                                 (path_pos[1] * shared.CELL_SIDE) + 4 + delta_y,
                                 4, 4
@@ -156,10 +462,10 @@ def draw_all_mobs(scrref):
 
 
 def player_push(directio):
-    player = pyv.find_by_archetype('player')[0]
-    # monsters = pyv.find_by_archetype('monster')  # TODO kick mob feat. here?
-    if (player['position'][0], player['position'][1]) not in shared.walkable_cells:
-        # print('kick')
+    player = pyv.find_by_archetype("player")[0]
+    # monsters = pyv.find_by_archetype("monster")  # TODO kick mob feat. here?
+    if (player["position"][0], player["position"][1]) not in shared.walkable_cells:
+        # print("kick")
         # shared.messages.append("Wall")
         deltas = {
             0: (+1, 0),
@@ -167,7 +473,7 @@ def player_push(directio):
             2: (-1, 0),
             3: (0, +1)
         }
-        player['position'][0] -= deltas[directio][0]
-        player['position'][1] -= deltas[directio][1]
+        player["position"][0] -= deltas[directio][0]
+        player["position"][1] -= deltas[directio][1]
     # Update player vision
-    world.update_vision_and_mobs(player['position'][0], player['position'][1])
+    world.update_vision_and_mobs(player["position"][0], player["position"][1])

--- a/ecsRogue/cartridge/util.py
+++ b/ecsRogue/cartridge/util.py
@@ -325,7 +325,7 @@ def get_score_table():
     # Game Jolt API version (desktop mode)
     
     if not shared.gamejoltapi:
-        shared.SCORE_TABLE.append("Highscore table temporally unavailable")
+        shared.SCORE_TABLE = ["Highscore table temporally unavailable"]
         return
     
     scores_payload = shared.gamejoltapi.scoresFetch(shared.NO_TOP_SCORES, shared.TEST_SCORE_TABLE_ID)
@@ -336,7 +336,7 @@ def get_score_table():
             ts = f"{datetime.fromtimestamp(score["stored_timestamp"])}"
             shared.SCORE_TABLE.append([str(rank+1), score["guest"], score["sort"], ts])
     else:
-        shared.SCORE_TABLE.append("Highscore table temporally unavailable")
+        shared.SCORE_TABLE = ["Highscore table temporally unavailable"]
         
         
 async def get_score_table_async():
@@ -350,7 +350,7 @@ async def get_score_table_async():
     # get top scores
     # print("gamejoltapi.scoresFetch")
     if not shared.gamejoltapi:
-        shared.SCORE_TABLE.append("Highscore table temporally unavailable")
+        shared.SCORE_TABLE = ["Highscore table temporally unavailable"]
         return
 
     scores_payload = await shared.gamejoltapi.scoresFetch(shared.NO_TOP_SCORES, shared.TEST_SCORE_TABLE_ID)
@@ -363,7 +363,7 @@ async def get_score_table_async():
             ts = f"{datetime.fromtimestamp(score["stored_timestamp"])}"
             shared.SCORE_TABLE.append([str(rank+1), score["guest"], score["sort"], ts])
     else:
-        shared.SCORE_TABLE.append("Highscore table temporally unavailable")
+        shared.SCORE_TABLE = ["Highscore table temporally unavailable"]
 
 
 def render_score_table(scr):

--- a/ecsRogue/cartridge/world.py
+++ b/ecsRogue/cartridge/world.py
@@ -1,26 +1,10 @@
 import random
 from . import shared
 from . import pimodules
-# from pygame_menu.examples import create_example_window
 
 pyv = pimodules.pyved_engine
 pyv.bootstrap_e()
 pygame = pyv.pygame
-
-# from . import gamejoltapi
-# import gamejoltapi
-
-# import pygame_menu
-# pygame_menu_ce not working with pygbag:
-#   File "/data/data/ecsrogue/assets/cartridge/systems.py", line 266, in rendering_sys
-#     shared.menu.draw(view)
-#   File "/data/data/org.python/assets/build/env/pygame_menu/menu.py", line 2117, in draw
-#     self._current._menubar.draw(surface)
-#   File "/data/data/org.python/assets/build/env/pygame_menu/widgets/core/widget.py", line 1391, in draw
-#     self._draw(surface)
-#   File "/data/data/org.python/assets/build/env/pygame_menu/widgets/widget/menubar.py", line 250, in _draw
-#     gfxdraw.filled_polygon(surface, self._polygon_pos, self._background_color)
-# pygame.error: Parameter 'renderer' is invalid
 
 
 def start_game():
@@ -28,7 +12,7 @@ def start_game():
     shared.show_input = False
     shared.menu.disable()
 
-    
+
 def create_player():
     player = pyv.new_from_archetype('player')
     pyv.init_entity(player, {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pygbag>=0.9.1
 pyved-engine>=24.4a2
+gamejoltapi==0.0.3


### PR DESCRIPTION
There are 3 implementations of highscore:
1. using GameJolt API for desktop mode
   * unfortunately it doesn't work yet when run in the web browser
   * API does the all heavy lifting
   * scores are kept online and there is one common score board for all users no matter when the game is run
2. Local storage in web browser
   * uses the build in Web browser functionality called 'local storage'
   * highscore table is kept in your browser locally and bind to url (domain:port, eg.: pyvm.kata.games, localhost:8000, 127.0.0.1:8000) so it's decentralized
   * it can be viewed and edited in browser (e.g. in Chrome: Developer Tools -> Applications -> Storage -> Local storage -> url)
3. Local storage stub
   * stubs local storage to make it easier to debug
   * when enabled, you can run game in desktop mode and still test it (view console, quick restart, etc.)
   * the data is kept in global dictionary (HIGHSCORE_STUB) instead of actual browser local storage
   * it's restored to original state with each game run
