### PR TITLE
Use the PYV pattern for gamestates

### DIFF
--- a/ecsRogue/cartridge/gamedef.py
+++ b/ecsRogue/cartridge/gamedef.py
@@ -1,145 +1,57 @@
 from . import pimodules
-from . import shared
-from . import systems
-from . import world
-from .util import clear_local_score_table
 # from pygame_menu.examples import create_example_window
 
-# from . import gamejoltapi
-if not shared.IS_WEB:
-    import gamejoltapi
 
 pyv = pimodules.pyved_engine
-pygame = pyv.pygame
+pyv.bootstrap_e()
 
 
-"""
-Readability Buff:
-if the world.py contains info about the game MODEL, it's better to init data related to graphics elsewhere,
-or just here in the main file
-"""
-from .classes import InputBox
-
-
-Spritesheet = pyv.gfx.Spritesheet  # TODO avoid using this, prefer using pyv pre-built spritesheet loading mechanism
-
-
-def init_images():
-    grid_rez = (32, 32)
-
-    # img = pyv.vars.images['tileset']
-    shared.joker_tile = pygame.Surface((32, 32))
-    shared.joker_tile.fill(pyv.pal.japan['peach'])
-    shared.exit_tile = pyv.vars.images['exit_tile']
-    shared.pot_tile = pyv.vars.images['pot_tile']
-
-    # TODO: can fix this in js web ctx?
-    # tileset = Spritesheet(img, 2)  # use upscaling x2
-    # tileset.set_infos(grid_rez)
-    # shared.TILESET = tileset
-    tileset_spr_sheet = pyv.vars.spritesheets['tileset']
-    shared.TILESET = tileset_spr_sheet
-
-    # old avatar:
-    # img = pyv.vars.images['avatar1']
-    # planche_avatar = Spritesheet(img, 2)  # upscaling x2
-    # planche_avatar.set_infos(grid_rez)
-    # planche_avatar.colorkey = (255, 0, 255)
-
-    monster_img = pyv.vars.images['monster']
-
-    # old avatar:
-    # shared.AVATAR = planche_avatar.image_by_rank(0)
-    # new avatar:
-    avatar_spr_sheet = pyv.vars.spritesheets['smallninja_sprites']
-    shared.AVATAR = avatar_spr_sheet['av0.png']
-
-    shared.MONSTER = monster_img
-
-
-def load_fonts():
-    font_sizes = [shared.FONT_SIZE_SMALL, shared.FONT_SIZE_MEDIUM, shared.FONT_SIZE_LARGE]
-    for font_size in font_sizes:
-        shared.fonts[font_size] = pyv.pygame.font.Font(None, font_size)
-
-
-def init_menu():
-    # import pygame_menu
-    # pygame_menu_ce not working with pygbag:
-    #   File "/data/data/ecsrogue/assets/cartridge/systems.py", line 266, in rendering_sys
-    #     shared.menu.draw(view)
-    #   File "/data/data/org.python/assets/build/env/pygame_menu/menu.py", line 2117, in draw
-    #     self._current._menubar.draw(surface)
-    #   File "/data/data/org.python/assets/build/env/pygame_menu/widgets/core/widget.py", line 1391, in draw
-    #     self._draw(surface)
-    #   File "/data/data/org.python/assets/build/env/pygame_menu/widgets/widget/menubar.py", line 250, in _draw
-    #     gfxdraw.filled_polygon(surface, self._polygon_pos, self._background_color)
-    # pygame.error: Parameter 'renderer' is invalid
-    
-    # shared.menu = pygame_menu.Menu(
-    #     height=300,
-    #     theme=pygame_menu.themes.THEME_BLUE,
-    #     title='Welcome',
-    #     width=400
-    # )
-    # shared.user_name_input = shared.menu.add.text_input('Name: ', default='', maxchar=10)
-    # # menu.add.selector('Difficulty: ', [('Hard', 1), ('Easy', 2)], onchange=set_difficulty)
-    # shared.menu.add.button('Play', start_game)
-    # shared.menu.add.button('Quit', pygame_menu.events.EXIT)
-    if not shared.IS_WEB:
-        if len(shared.GAME_ID) > 0 and len(shared.PRIVATE_KEY) > 0 and shared.PROD_SCORE_TABLE_ID > 0:
-            shared.gamejoltapi = gamejoltapi.GameJoltAPI(
-                shared.GAME_ID,
-                shared.PRIVATE_KEY,
-                # username=USERNAME,
-                # userToken=TOKEN,
-                responseFormat="json",
-                submitRequests=True
-            )
-        else:
-            print("*" * 50)
-            print("GameJolt API needs proper GAME_ID, PRIVATE_KEY and PROD_SCORE_TABLE_ID to be set. See shared.py for more details.")
-            print("HIGHSCORE table will be disabled.")
-            print("*" * 50)
-
-    shared.user_name_input = InputBox(135, 205, 140, 32, max_len=10)
+from . import shared
+from .states import *  # classes: TitleState, ExploreState
 
 
 @pyv.declare_begin
 def init_game(vmst=None):
     pyv.init(wcaption='Roguata')
 
-    screen = pyv.get_surface()
-    shared.screen = screen
-    pyv.define_archetype('player', (
-        'position', 'controls', 'body', 'damages', 'health_point', 'enter_new_map',
-    ))
-    # pyv.define_archetype('wall', ('body',))
-    pyv.define_archetype('monster', ('position', 'damages', 'health_point', 'active', 'color', 'path', 'no'))
-    pyv.define_archetype('exit', ('position',))
-    pyv.define_archetype('potion', ('position', 'effect',))
+    # because we use the gamestates mechanism, it is mandatory to activate pyv event system as well:
+    ev_mger = pyv.get_ev_manager()
+    ev_mger.setup()
+    gs_enum = shared.GameStates
 
-    world.create_player()
-    # world.create_wall()
-    world.create_exit()
-    # world.create_potion()
+    pyv.declare_game_states(gs_enum, {
+        gs_enum.TitleScreen: TitleState,
+        gs_enum.Explore: ExploreState
+    })
 
-    init_images()
-    load_fonts()
-    init_menu()
-
-    # clear_local_score_table()
-    pyv.bulk_add_systems(systems)
+    # We need these two instruction to enforce the call to .enter() on TitleState!
+    # import pyved_engine
+    # pyved_engine.events.KengiEv
+    # pyved_engine.EngineEvTypes
+    # debug:
+    # print(pyv.EngineEvTypes.inv_map)
+    ev_mger.post(
+        pyv.EngineEvTypes.Gamestart
+    )
+    ev_mger.update()
 
 
 @pyv.declare_update
 def upd(time_info=None):
-    pyv.systems_proc()
+    if pyv.curr_state() == shared.GameStates.Explore:  # hacky solution,
+        # because not all gamestates uses the ECS pattern,
+        # hence the test w.r.t pyv.curr_state()è
+        pyv.systems_proc()
+    else:
+        ev_mgr = pyv.get_ev_manager()
+        ev_mgr.post(pyv.EngineEvTypes.Paint, screen=pyv.vars.screen)
+        tnow = time_info if time_info else pyv.vars.clock.get_time()
+        ev_mgr.post(pyv.EngineEvTypes.Update, curr_t=tnow)
+        ev_mgr.update()
+
     pyv.flip()
-    # shared.sys_iterator = 0
 
 
 @pyv.declare_end
 def done(vmst=None):
     pyv.close_game()
-    # print('gameover!')

--- a/ecsRogue/cartridge/metadat.json
+++ b/ecsRogue/cartridge/metadat.json
@@ -1,5 +1,5 @@
 {
-    "vmlib_ver": "24_4a2",
+    "vmlib_ver": "24_4a3",
     "dependencies": {
         "pyved_engine": "???"
     },

--- a/ecsRogue/cartridge/shared.py
+++ b/ecsRogue/cartridge/shared.py
@@ -1,6 +1,13 @@
+from . import pimodules
 from pathlib import Path
 
-GAME_VER = "0.9"
+GAME_VER = "1.0"
+
+pyv = pimodules.pyved_engine
+GameStates = pyv.e_struct.enum(
+    'TitleScreen', 'Explore'
+)
+
 # print exceptions in GUI only in debug mode (useful for debugging highscore local web storage when there is no terminal)
 IS_DEBUG = True # check if we can use __debug__ with pyved and pygbag
 

--- a/ecsRogue/cartridge/states.py
+++ b/ecsRogue/cartridge/states.py
@@ -1,0 +1,168 @@
+from .classes import InputBox
+from . import pimodules
+from . import shared
+from . import world
+from . import systems
+# from . import gamejoltapi
+if not shared.IS_WEB:
+    import gamejoltapi
+
+# import pyved_engine
+# t = pyved_engine.pal.c64
+
+__all__ = [
+    'TitleState',
+    'ExploreState'
+]
+
+
+pyv = pimodules.pyved_engine
+
+
+def init_images():
+    grid_rez = (32, 32)
+
+    # img = pyv.vars.images['tileset']
+    shared.joker_tile = pyv.pygame.Surface((32, 32))
+    shared.joker_tile.fill(pyv.pal.japan['peach'])
+    shared.exit_tile = pyv.vars.images['exit_tile']
+    shared.pot_tile = pyv.vars.images['pot_tile']
+
+    # TODO: can fix this in js web ctx?
+    # tileset = Spritesheet(img, 2)  # use upscaling x2
+    # tileset.set_infos(grid_rez)
+    # shared.TILESET = tileset
+    tileset_spr_sheet = pyv.vars.spritesheets['tileset']
+    shared.TILESET = tileset_spr_sheet
+
+    # old avatar:
+    # img = pyv.vars.images['avatar1']
+    # planche_avatar = Spritesheet(img, 2)  # upscaling x2
+    # planche_avatar.set_infos(grid_rez)
+    # planche_avatar.colorkey = (255, 0, 255)
+
+    monster_img = pyv.vars.images['monster']
+
+    # old avatar:
+    # shared.AVATAR = planche_avatar.image_by_rank(0)
+    # new avatar:
+    avatar_spr_sheet = pyv.vars.spritesheets['smallninja_sprites']
+    shared.AVATAR = avatar_spr_sheet['av0.png']
+
+    shared.MONSTER = monster_img
+
+
+def load_fonts():
+    font_sizes = [shared.FONT_SIZE_SMALL, shared.FONT_SIZE_MEDIUM, shared.FONT_SIZE_LARGE]
+    for font_size in font_sizes:
+        shared.fonts[font_size] = pyv.pygame.font.Font(None, font_size)
+
+
+def init_menu():
+    # import pygame_menu
+    # pygame_menu_ce not working with pygbag:
+    #   File "/data/data/ecsrogue/assets/cartridge/systems.py", line 266, in rendering_sys
+    #     shared.menu.draw(view)
+    #   File "/data/data/org.python/assets/build/env/pygame_menu/menu.py", line 2117, in draw
+    #     self._current._menubar.draw(surface)
+    #   File "/data/data/org.python/assets/build/env/pygame_menu/widgets/core/widget.py", line 1391, in draw
+    #     self._draw(surface)
+    #   File "/data/data/org.python/assets/build/env/pygame_menu/widgets/widget/menubar.py", line 250, in _draw
+    #     gfxdraw.filled_polygon(surface, self._polygon_pos, self._background_color)
+    # pygame.error: Parameter 'renderer' is invalid
+
+    # shared.menu = pygame_menu.Menu(
+    #     height=300,
+    #     theme=pygame_menu.themes.THEME_BLUE,
+    #     title='Welcome',
+    #     width=400
+    # )
+    # shared.user_name_input = shared.menu.add.text_input('Name: ', default='', maxchar=10)
+    # # menu.add.selector('Difficulty: ', [('Hard', 1), ('Easy', 2)], onchange=set_difficulty)
+    # shared.menu.add.button('Play', start_game)
+    # shared.menu.add.button('Quit', pygame_menu.events.EXIT)
+    if not shared.IS_WEB:
+        if len(shared.GAME_ID) > 0 and len(shared.PRIVATE_KEY) > 0 and shared.PROD_SCORE_TABLE_ID > 0:
+            shared.gamejoltapi = gamejoltapi.GameJoltAPI(
+                shared.GAME_ID,
+                shared.PRIVATE_KEY,
+                # username=USERNAME,
+                # userToken=TOKEN,
+                responseFormat="json",
+                submitRequests=True
+            )
+        else:
+            print("*" * 50)
+            print(
+                "GameJolt API needs proper GAME_ID, PRIVATE_KEY and PROD_SCORE_TABLE_ID to be set. See shared.py for more details.")
+            print("HIGHSCORE table will be disabled.")
+            print("*" * 50)
+
+    shared.user_name_input = InputBox(135, 205, 140, 32, max_len=10)
+
+
+class DummyPrinter(pyv.EvListener):
+    def __init__(self):
+        super().__init__()
+        self.ft = pyv.pygame.font.Font(None, 24)
+        self.label = self.ft.render('press SPACE to play, ESC to exit game', False, pyv.pal.c64['red'])
+
+    def on_paint(self, ev):
+        ev.screen.fill(pyv.pal.c64['lightgrey'])
+        ev.screen.blit(self.label, (8, 48))
+
+    def on_keydown(self, ev):
+        if ev.key == pyv.pygame.K_SPACE:
+            self.pev(pyv.EngineEvTypes.StateChange, state_ident=shared.GameStates.Explore)
+
+        elif ev.key == pyv.pygame.K_ESCAPE:
+            pyv.vars.gameover = True
+
+        else:
+            print('not recognized key')
+
+
+# ---------------------
+#  public classes
+# ---------------------
+class TitleState(pyv.BaseGameState):
+    def __init__(self, param):
+        super().__init__(0)
+        self.tmp_painter = None
+
+    def enter(self):
+        self.tmp_painter = DummyPrinter()
+        self.tmp_painter.turn_on()
+
+    def release(self):
+        print('out of TitleState, now!')
+        self.tmp_painter.turn_off()
+
+
+class ExploreState(pyv.BaseGameState):
+    def enter(self):
+        print('*** dans ENTER')
+        screen = pyv.get_surface()
+        shared.screen = screen
+        pyv.define_archetype('player', (
+            'position', 'controls', 'body', 'damages', 'health_point', 'enter_new_map',
+        ))
+        # pyv.define_archetype('wall', ('body',))
+        pyv.define_archetype('monster', ('position', 'damages', 'health_point', 'active', 'color', 'path', 'no'))
+        pyv.define_archetype('exit', ('position',))
+        pyv.define_archetype('potion', ('position', 'effect',))
+
+        world.create_player()
+        # world.create_wall()
+        world.create_exit()
+        # world.create_potion()
+
+        init_images()
+        load_fonts()
+        init_menu()
+
+        # clear_local_score_table()
+        pyv.bulk_add_systems(systems)
+
+    def release(self):
+        print('exit the main game mode')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pygbag>=0.9.1
-pyved-engine>=24.4a2
 gamejoltapi==0.0.3
+git+https://github.com/gaudiatech/pyved-engine.git


### PR DESCRIPTION
Let's switch to using a pattern instead of no pattern for gamestates.

In that way we can have a nice structure in the code for (a few examples):

- the title screen
- a highscores screen
- the main game state (could be called: *Explore / Exploration*)

In this pull request I added a few minors changes. The most interesting one:

- `requirements.txt` have been changed in order to use the very last (bleeding edge) version, in that way you don't need to wait for a release in order to benefit from recent updates in the pyved-engine